### PR TITLE
move gemmy further to the right

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@ If your plugin does not need CSS, delete this file.
 .gemmy-container {
         position: fixed;
         bottom: 30px;
-        right: 30px;
+        right: 0;
 }
 
 .gemmy-container img {


### PR DESCRIPTION
This prevents Gemmy covering content in your right sidebar. 

Gemmy might not be useful to increase your productivity, but they also should not decrease your productivity! :gemmymelt:

before
![CleanShot 2023-04-17 at 12 36 21@2x](https://user-images.githubusercontent.com/73286100/232460599-60fed6eb-3b63-4d26-99e0-d05d577c83a5.png)

after
![CleanShot 2023-04-17 at 12 35 54@2x](https://user-images.githubusercontent.com/73286100/232460492-e41c8609-5dd3-4afa-af19-6f0882ac98b4.png)
